### PR TITLE
Use default formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/target
+/target/
+/.idea/
 **/*.rs.bk
 /Cargo.lock
 /waffle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["playx"]
 edition = "2018"
 
 [dependencies]
-hmap = "0.1.0"
-fxhash = "0.2.1"
-rand = "0.6.5"
-walkdir = "2.2.7"
+hmap = "0.1"
+fxhash = "0.2"
+rand = "0.6"
+walkdir = "2.2"
+hashbrown = "0.1"
+time = "0.1"
+structopt = "0.2"
+crossterm = "0.6"
+
 jazzvm = {path = "vm"}
-hashbrown = "0.1.8"
 gc = {path = "gc-rs/gc"}
-time = "0.1.42"
-structopt = "0.2.15"
-crossterm = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # Jazz
 Simple dynamically typed language inspired by ML, Neko and Rust
-

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-indent_style="Visual"
-control_brace_style="AlwaysNextLine"
-brace_style="AlwaysNextLine"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,22 +1,20 @@
 use crate::token::Position;
 
 #[derive(Clone, PartialEq)]
-pub struct Expr
-{
+pub struct Expr {
     pub pos: Position,
     pub expr: ExprKind,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ExprKind
-{
+pub enum ExprKind {
     Assign(Box<Expr>, Box<Expr>),
     BinOp(Box<Expr>, String, Box<Expr>),
     Unop(String, Box<Expr>),
     Access(Box<Expr>, String),
     Ident(String),
-    Function(String,Vec<String>, Box<Expr>),
-    Class(String,Box<Expr>,Option<Box<Expr>>),
+    Function(String, Vec<String>, Box<Expr>),
+    Class(String, Box<Expr>, Option<Box<Expr>>),
     Lambda(Vec<String>, Box<Expr>),
     Match(Box<Expr>, Vec<(Box<Expr>, Box<Expr>)>, Option<Box<Expr>>),
     If(Box<Expr>, Box<Expr>, Option<Box<Expr>>),
@@ -45,33 +43,25 @@ pub enum ExprKind
 
 use std::fmt;
 
-impl Expr
-{
-    pub fn is_access(&self) -> bool
-    {
-        if let ExprKind::Access(_, _) = self.expr
-        {
+impl Expr {
+    pub fn is_access(&self) -> bool {
+        if let ExprKind::Access(_, _) = self.expr {
             return true;
         };
         false
     }
 
-    pub fn is_binop(&self) -> bool
-    {
-        if let ExprKind::BinOp(_, _, _) = self.expr
-        {
+    pub fn is_binop(&self) -> bool {
+        if let ExprKind::BinOp(_, _, _) = self.expr {
             return true;
         };
         false
     }
 
-    pub fn is_binop_cmp(&self) -> bool
-    {
-        if let ExprKind::BinOp(_, ref op, _) = self.expr
-        {
+    pub fn is_binop_cmp(&self) -> bool {
+        if let ExprKind::BinOp(_, ref op, _) = self.expr {
             let op: &str = op;
-            match op
-            {
+            match op {
                 ">" | "<" | ">=" | "<=" | "==" | "!=" => return true,
                 _ => return false,
             }
@@ -80,10 +70,8 @@ impl Expr
     }
 }
 
-impl fmt::Debug for Expr
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
-    {
+impl fmt::Debug for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:#?}", self.expr)
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,55 +1,51 @@
-use hashbrown::HashMap;
-use hashbrown::HashSet;
-use jazzvm::instruction::*;
-use jazzvm::value::*;
-use jazzvm::vm::*;
+use hashbrown::{HashMap, HashSet};
+use jazzvm::{instruction::*, value::*, vm::*};
+
+use crate::ast::*;
+
 macro_rules! gc {
     ($e:expr) => {
         GcValue::new($e)
     };
 }
 
-use crate::ast::*;
-
-pub struct Compiler<'a>
-{
+pub struct Compiler<'a> {
     pub globals: HashMap<String, u32>,
     pub vm: &'a mut VirtualMachine,
     pub functions: HashSet<u32>,
     pub module: String,
 }
 
-impl<'a> Compiler<'a>
-{
-    pub fn new(vm: &'a mut VirtualMachine, module: String) -> Compiler<'a>
-    {
-        Compiler { globals: HashMap::new(),
-                   vm: vm,
-                   functions: HashSet::new(),
-                   module: module }
+impl<'a> Compiler<'a> {
+    pub fn new(vm: &'a mut VirtualMachine, module: String) -> Compiler<'a> {
+        Compiler {
+            globals: HashMap::new(),
+            vm: vm,
+            functions: HashSet::new(),
+            module: module,
+        }
     }
 
-    fn get_definitions(&mut self) -> HashMap<String, u32>
-    {
+    fn get_definitions(&mut self) -> HashMap<String, u32> {
         self.globals.clone()
     }
 
-    fn get_functions(&mut self) -> HashSet<u32>
-    {
+    fn get_functions(&mut self) -> HashSet<u32> {
         self.functions.clone()
     }
-    pub fn import(&mut self, fname: &str)
-    {
+
+    pub fn import(&mut self, fname: &str) {
         use crate::parser::Parser;
         use crate::reader::Reader;
         let reader = Reader::from_file(fname).expect("file not found");
         let mut ast = vec![];
         use std::path::Path;
-        let mname = Path::new(fname).file_stem()
-                                    .unwrap()
-                                    .to_str()
-                                    .unwrap()
-                                    .to_owned();
+        let mname = Path::new(fname)
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
 
         let mut parser = Parser::new(reader, &mut ast);
         parser.parse().unwrap();
@@ -59,8 +55,7 @@ impl<'a> Compiler<'a>
         //let fns = compiler.get_functions();
         let mut object = Object::new(&mname);
 
-        for (key, value) in defs.iter()
-        {
+        for (key, value) in defs.iter() {
             let v = self.vm.globals.get(value).unwrap();
             object.insert(gc!(Value::Str(key.to_string())), v.clone());
         }
@@ -69,17 +64,13 @@ impl<'a> Compiler<'a>
         self.globals.insert(mname, idx);
     }
 
-    pub fn compile_ast(&mut self, ast: Vec<Box<Expr>>)
-    {
+    pub fn compile_ast(&mut self, ast: Vec<Box<Expr>>) {
         crate::runtime::builtins(self);
 
-        for expr in ast.iter()
-        {
-            match &expr.expr
-            {
+        for expr in ast.iter() {
+            match &expr.expr {
                 ExprKind::Import(fname) => self.import(fname),
-                ExprKind::Include(fname) =>
-                {
+                ExprKind::Include(fname) => {
                     use crate::parser::Parser;
                     use crate::reader::Reader;
                     let reader = Reader::from_file(fname).unwrap();
@@ -89,11 +80,12 @@ impl<'a> Compiler<'a>
 
                     parser.parse().unwrap();
                     use std::path::Path;
-                    let mname = Path::new(fname).file_stem()
-                                                .unwrap()
-                                                .to_str()
-                                                .unwrap()
-                                                .to_owned();
+                    let mname = Path::new(fname)
+                        .file_stem()
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_owned();
 
                     let mut compiler = Compiler::new(self.vm, mname);
                     compiler.compile_ast(ast);
@@ -107,38 +99,33 @@ impl<'a> Compiler<'a>
                 _ => (),
             }
         }
-        for expr in ast.iter()
-        {
-            match &expr.expr
-            {
+        for expr in ast.iter() {
+            match &expr.expr {
                 ExprKind::Import(_fname) => (),
                 ExprKind::Include(_fname) => (),
-                ExprKind::Function(name, args, body) =>
-                {
-                    let function = Function { name: name.to_owned(),
-                                              var: FuncVar::Code(vec![], 0) };
+                ExprKind::Function(name, args, body) => {
+                    let function = Function {
+                        name: name.to_owned(),
+                        var: FuncVar::Code(vec![], 0),
+                    };
                     let fid = self.vm.new_global(gc!(Value::Func(function)));
                     self.globals.insert(name.to_owned(), fid);
                     let mut fbuilder = FunctionBuilder::new(self, args.len());
-                    for (idx, param) in args.iter().enumerate()
-                    {
+                    for (idx, param) in args.iter().enumerate() {
                         fbuilder.locals.insert(param.to_string(), idx as u16);
                     }
                     fbuilder.compile(body);
                     let max_locals = fbuilder.max_locals;
                     let code = fbuilder.finish();
-                    if cfg!(debug_assertions)
-                    {
+                    if cfg!(debug_assertions) {
                         println!("Disassemble of `{}` function", name);
-                        for (idx, op) in code.iter().enumerate()
-                        {
+                        for (idx, op) in code.iter().enumerate() {
                             println!("{:04} {:?}", idx, op);
                         }
                     }
                     let func = self.vm.globals.get(&fid).unwrap();
                     let val: &mut Value = &mut func.get_mut();
-                    let function = match val
-                    {
+                    let function = match val {
                         Value::Func(f) => f,
                         _ => unreachable!(),
                     };
@@ -147,52 +134,42 @@ impl<'a> Compiler<'a>
                     self.functions.insert(fid);
                 }
 
-                ExprKind::Class(name, block, _implements) =>
-                {
+                ExprKind::Class(name, block, _implements) => {
                     let object = Object::new(name);
-                    let oidx = if !self.globals.contains_key(name)
-                    {
+                    let oidx = if !self.globals.contains_key(name) {
                         let oidx = self.vm.new_global(gc!(Value::Object(object)));
                         self.globals.insert(name.to_owned(), oidx);
 
                         oidx
-                    }
-                    else
-                    {
+                    } else {
                         let idx = *self.globals.get(name).unwrap();
                         let obj = self.vm.globals.get(&idx).unwrap();
                         let obj_ref: &mut Value = &mut obj.get_mut();
-                        match obj_ref
-                        {
+                        match obj_ref {
                             Value::Object(obj) => *obj = object,
                             _ => unreachable!(),
                         }
                         idx
                     };
 
-                    if let ExprKind::Block(exprs) = &block.expr
-                    {
-                        for expr in exprs.iter()
-                        {
-                            match &expr.expr
-                            {
-                                ExprKind::Function(fname, args, block) =>
-                                {
-                                    let mut function = Function { name: fname.to_owned(),
-                                                                  var: FuncVar::Code(vec![], 0) };
+                    if let ExprKind::Block(exprs) = &block.expr {
+                        for expr in exprs.iter() {
+                            match &expr.expr {
+                                ExprKind::Function(fname, args, block) => {
+                                    let mut function = Function {
+                                        name: fname.to_owned(),
+                                        var: FuncVar::Code(vec![], 0),
+                                    };
                                     let mut fbuilder = FunctionBuilder::new(self, args.len());
-                                    for (idx, param) in args.iter().enumerate()
-                                    {
+                                    for (idx, param) in args.iter().enumerate() {
                                         fbuilder.locals.insert(param.to_string(), idx as u16);
                                     }
                                     fbuilder.compile(block);
                                     let max_locals = fbuilder.max_locals;
                                     let code = fbuilder.finish();
-                                    if cfg!(debug_assertions)
-                                    {
+                                    if cfg!(debug_assertions) {
                                         println!("Disassemble of `{}::{}` function", name, fname);
-                                        for (idx, op) in code.iter().enumerate()
-                                        {
+                                        for (idx, op) in code.iter().enumerate() {
                                             println!("{:04} {:?}", idx, op);
                                         }
                                     }
@@ -202,13 +179,14 @@ impl<'a> Compiler<'a>
                                     let object = self.vm.globals.get(&oidx).unwrap();
 
                                     let object: &mut Value = &mut object.get_mut();
-                                    let object: &mut Object = match object
-                                    {
+                                    let object: &mut Object = match object {
                                         Value::Object(obj) => obj,
                                         _ => unreachable!(),
                                     };
-                                    object.insert(gc!(Value::Str(fname.to_owned())),
-                                                  gc!(Value::Func(function)));
+                                    object.insert(
+                                        gc!(Value::Str(fname.to_owned())),
+                                        gc!(Value::Func(function)),
+                                    );
                                 }
                                 _ => unimplemented!(),
                             }
@@ -224,16 +202,14 @@ impl<'a> Compiler<'a>
 impl<'a> Compiler<'a> {}
 
 #[derive(Clone, Debug)]
-pub enum UOP
-{
+pub enum UOP {
     Goto(String),
     GotoF(String),
     GotoT(String),
     Op(Instruction),
 }
 
-pub struct FunctionBuilder<'a, 'b: 'a>
-{
+pub struct FunctionBuilder<'a, 'b: 'a> {
     compiler: &'a mut Compiler<'b>,
     locals: HashMap<String, u16>,
     /// This field is required for `break` in `while` (Check `check_labels` documentation)
@@ -256,113 +232,89 @@ pub struct FunctionBuilder<'a, 'b: 'a>
     max_locals: u16,
 }
 
-impl<'a, 'b: 'a> FunctionBuilder<'a, 'b>
-{
-    pub fn new(cmpl: &'a mut Compiler<'b>, argc: usize) -> FunctionBuilder<'a, 'b>
-    {
+impl<'a, 'b: 'a> FunctionBuilder<'a, 'b> {
+    pub fn new(cmpl: &'a mut Compiler<'b>, argc: usize) -> FunctionBuilder<'a, 'b> {
         let mut max_locals = 0;
-        for _ in 0..argc as u16
-        {
+        for _ in 0..argc as u16 {
             max_locals += 1;
         }
-        FunctionBuilder { compiler: cmpl,
-                          max_locals,
-                          locals: HashMap::new(),
-                          end_labels: vec![],
-                          check_labels: vec![],
-                          ins: vec![],
-                          labels: HashMap::new() }
+        FunctionBuilder {
+            compiler: cmpl,
+            max_locals,
+            locals: HashMap::new(),
+            end_labels: vec![],
+            check_labels: vec![],
+            ins: vec![],
+            labels: HashMap::new(),
+        }
     }
     #[inline]
-    fn new_varid(&mut self) -> u16
-    {
+    fn new_varid(&mut self) -> u16 {
         self.max_locals += 1;
         self.locals.len() as u16
     }
-    fn emit(&mut self, op: Instruction)
-    {
+    fn emit(&mut self, op: Instruction) {
         self.ins.push(UOP::Op(op));
     }
-    pub fn finish(&mut self) -> Vec<Instruction>
-    {
-        let ins =
-            self.ins
-                .clone()
-                .iter()
-                .map(|i| match &i
-                {
-                    &UOP::Goto(s) => Instruction::Br(self.labels.get(s).unwrap().unwrap() as u16),
-                    &UOP::GotoF(s) => Instruction::Brz(self.labels.get(s).unwrap().unwrap() as u16),
-                    &UOP::GotoT(s) =>
-                    {
-                        Instruction::Brnz(self.labels.get(s).unwrap().unwrap() as u16)
-                    }
-                    &UOP::Op(op) => op.clone(),
-                })
-                .collect::<Vec<Instruction>>();
+    pub fn finish(&mut self) -> Vec<Instruction> {
+        let ins = self
+            .ins
+            .clone()
+            .iter()
+            .map(|i| match &i {
+                &UOP::Goto(s) => Instruction::Br(self.labels.get(s).unwrap().unwrap() as u16),
+                &UOP::GotoF(s) => Instruction::Brz(self.labels.get(s).unwrap().unwrap() as u16),
+                &UOP::GotoT(s) => Instruction::Brnz(self.labels.get(s).unwrap().unwrap() as u16),
+                &UOP::Op(op) => op.clone(),
+            })
+            .collect::<Vec<Instruction>>();
         ins
     }
-    pub fn new_empty_label(&mut self) -> String
-    {
+    pub fn new_empty_label(&mut self) -> String {
         let lab_name = self.labels.len().to_string();
         self.labels.insert(lab_name.clone(), None);
         lab_name
     }
 
-    pub fn label_here(&mut self, label: &str)
-    {
+    pub fn label_here(&mut self, label: &str) {
         *self.labels.get_mut(label).expect("lbl not exists") = Some(self.ins.len());
     }
 
-    pub fn compile(&mut self, expr: &Box<Expr>)
-    {
-        match &expr.expr
-        {
+    pub fn compile(&mut self, expr: &Box<Expr>) {
+        match &expr.expr {
             ExprKind::ConstInt(i) => self.emit(Instruction::LdInt(*i)),
             ExprKind::ConstFloat(f) => self.emit(Instruction::LdFloat(f.to_bits())),
             ExprKind::ConstStr(s) => self.emit(Instruction::LdString(s.clone())),
             ExprKind::ConstBool(b) => self.emit(Instruction::LdBool(*b)),
-            ExprKind::Var(_, name, init) =>
-            {
+            ExprKind::Var(_, name, init) => {
                 let id = self.new_varid();
-                if init.is_some()
-                {
+                if init.is_some() {
                     let val = init.clone().unwrap();
                     self.compile(&val);
                     self.emit(Instruction::StLoc(id));
-                }
-                else
-                {
+                } else {
                     /* Do nothing */
                 }
                 self.locals.insert(name.to_string(), id);
             }
-            ExprKind::Array(values) =>
-            {
-                for val in values.iter().rev()
-                {
+            ExprKind::Array(values) => {
+                for val in values.iter().rev() {
                     self.compile(val);
                 }
                 self.emit(Instruction::MakeArray(values.len() as u16));
             }
 
-            ExprKind::Ident(name) =>
-            {
-                if self.compiler.globals.contains_key(name)
-                {
+            ExprKind::Ident(name) => {
+                if self.compiler.globals.contains_key(name) {
                     let id = self.compiler.globals.get(name).unwrap();
                     self.emit(Instruction::LdGlob(*id));
-                }
-                else
-                {
-                    if name == "_ARGS_"
-                    {
+                } else {
+                    if name == "_ARGS_" {
                         self.emit(Instruction::LdArgs);
                         return;
                     }
                     let id = self.locals.get(name);
-                    if id.is_none()
-                    {
+                    if id.is_none() {
                         panic!("error at {}: Variable `{}` not defined", expr.pos, name);
                     };
                     let id = id.unwrap();
@@ -370,32 +322,24 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b>
                 }
             }
             ExprKind::This => self.emit(Instruction::LdThis),
-            ExprKind::Access(val, field) =>
-            {
+            ExprKind::Access(val, field) => {
                 self.compile(&val);
                 self.emit(Instruction::LdString(field.to_string()));
                 self.emit(Instruction::LdFld);
             }
-            ExprKind::Assign(var, to) =>
-            {
+            ExprKind::Assign(var, to) => {
                 self.compile(&to);
-                match &var.expr
-                {
-                    ExprKind::Ident(name) =>
-                    {
-                        if self.locals.contains_key(name)
-                        {
+                match &var.expr {
+                    ExprKind::Ident(name) => {
+                        if self.locals.contains_key(name) {
                             let id = self.locals.get(name).unwrap();
                             self.emit(Instruction::StLoc(*id));
-                        }
-                        else
-                        {
+                        } else {
                             let id = self.compiler.globals.get(name).unwrap();
                             self.emit(Instruction::StGlob(*id));
                         }
                     }
-                    ExprKind::Access(obj, field) =>
-                    {
+                    ExprKind::Access(obj, field) => {
                         self.compile(&to);
                         self.emit(Instruction::LdString(field.to_string()));
                         self.compile(&obj);
@@ -404,20 +348,16 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b>
                     _ => unimplemented!(),
                 }
             }
-            ExprKind::Block(exprs) =>
-            {
-                for expr in exprs.iter()
-                {
+            ExprKind::Block(exprs) => {
+                for expr in exprs.iter() {
                     self.compile(expr);
                 }
             }
-            ExprKind::BinOp(lhs, op, rhs) =>
-            {
+            ExprKind::BinOp(lhs, op, rhs) => {
                 let op: &str = op;
                 self.compile(&rhs);
                 self.compile(&lhs);
-                let ins = match op
-                {
+                let ins = match op {
                     "+" => Instruction::Add,
                     "-" => Instruction::Sub,
                     "*" => Instruction::Mul,
@@ -433,32 +373,27 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b>
                 };
                 self.emit(ins);
             }
-            ExprKind::Unop(op, val) =>
-            {
+            ExprKind::Unop(op, val) => {
                 self.compile(&val);
                 let op: &str = op;
-                match op
-                {
+                match op {
                     "-" => self.emit(Instruction::Neg),
                     _ => unimplemented!(),
                 }
             }
-            ExprKind::If(cond, then, or) =>
-            {
+            ExprKind::If(cond, then, or) => {
                 let lbl_false = self.new_empty_label();
 
                 self.compile(&cond);
                 self.ins.push(UOP::GotoF(lbl_false.clone()));
                 self.compile(&then);
                 self.label_here(&lbl_false);
-                if or.is_some()
-                {
+                if or.is_some() {
                     let or = or.clone().unwrap();
                     self.compile(&or);
                 }
             }
-            ExprKind::While(cond, repeat) =>
-            {
+            ExprKind::While(cond, repeat) => {
                 let compare = self.new_empty_label();
                 let end = self.new_empty_label();
                 self.label_here(&compare);
@@ -470,55 +405,41 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b>
                 self.ins.push(UOP::Goto(compare));
                 self.label_here(&end);
             }
-            ExprKind::Call(val, args) =>
-            {
-                for arg in args.iter().rev()
-                {
+            ExprKind::Call(val, args) => {
+                for arg in args.iter().rev() {
                     self.compile(arg);
                 }
 
-                if let ExprKind::Access(obj, field) = &val.expr
-                {
+                if let ExprKind::Access(obj, field) = &val.expr {
                     self.compile(&obj);
                     self.emit(Instruction::Dup);
                     self.emit(Instruction::LdString(field.to_string()));
                     self.emit(Instruction::LdFld);
-                }
-                else
-                {
+                } else {
                     self.emit(Instruction::LdNull);
                     self.compile(val);
                 }
                 self.emit(Instruction::Invoke(args.len() as u16));
             }
-            ExprKind::Return(exp) =>
-            {
-                if exp.is_some()
-                {
+            ExprKind::Return(exp) => {
+                if exp.is_some() {
                     let expr = exp.clone().unwrap();
                     self.compile(&expr);
                     self.emit(Instruction::Ret);
-                }
-                else
-                {
+                } else {
                     self.emit(Instruction::LdNull);
                     self.emit(Instruction::Ret);
                 }
             }
-            ExprKind::New(init_class) =>
-            {
-                if let ExprKind::Call(to_call, args) = &init_class.expr
-                {
-                    for arg in args.iter().rev()
-                    {
+            ExprKind::New(init_class) => {
+                if let ExprKind::Call(to_call, args) = &init_class.expr {
+                    for arg in args.iter().rev() {
                         self.compile(arg);
                     }
                     self.compile(to_call);
 
                     self.emit(Instruction::New(args.len() as u16));
-                }
-                else
-                {
+                } else {
                     panic!("Call expected");
                 }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -96,8 +96,7 @@ impl<'a> Compiler<'a> {
                     self.globals.extend(defs);
                     self.functions.extend(fns);
                 }
-                ExprKind::IncludeUrl(name) =>
-                {
+                ExprKind::IncludeUrl(name) => {
                     use crate::parser::Parser;
                     use crate::reader::Reader;
                     use reqwest::get;
@@ -109,11 +108,12 @@ impl<'a> Compiler<'a> {
 
                     parser.parse().unwrap();
                     use std::path::Path;
-                    let mname = Path::new(name).file_stem()
-                                                .unwrap()
-                                                .to_str()
-                                                .unwrap()
-                                                .to_owned();
+                    let mname = Path::new(name)
+                        .file_stem()
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_owned();
 
                     let mut compiler = Compiler::new(self.vm, mname);
                     compiler.compile_ast(ast);
@@ -279,17 +279,17 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b> {
         }
     }
     #[inline]
-  
+
     fn new_varid(&mut self) -> u16 {
         let id = self.max_locals;
         self.max_locals += 1;
         self.max_locals
     }
-    
+
     fn emit(&mut self, op: Instruction) {
         self.ins.push(UOP::Op(op));
     }
-    
+
     pub fn finish(&mut self) -> Vec<Instruction> {
         let ins = self
             .ins
@@ -304,7 +304,7 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b> {
             .collect::<Vec<Instruction>>();
         ins
     }
-      
+
     pub fn new_empty_label(&mut self) -> String {
         let lab_name = self.labels.len().to_string();
         self.labels.insert(lab_name.clone(), None);
@@ -322,32 +322,23 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b> {
             ExprKind::ConstStr(s) => self.emit(Instruction::LdString(s.clone())),
             ExprKind::ConstBool(b) => self.emit(Instruction::LdBool(*b)),
             ExprKind::Var(_, name, init) => {
-                if !self.locals.contains_key(name)
-                {
+                if !self.locals.contains_key(name) {
                     let id = self.new_varid();
-                    if init.is_some()
-                    {
+                    if init.is_some() {
                         let val = init.clone().unwrap();
                         self.compile(&val);
                         self.emit(Instruction::StLoc(id));
-                    }
-                    else
-                    {
+                    } else {
                         /* Do nothing */
                     }
                     self.locals.insert(name.to_string(), id);
-                }
-                else
-                {
+                } else {
                     let id = *self.locals.get(name).unwrap();
-                    if init.is_some()
-                    {
+                    if init.is_some() {
                         let val = init.clone().unwrap();
                         self.compile(&val);
                         self.emit(Instruction::StLoc(id));
-                    }
-                    else
-                    {
+                    } else {
                         /* Do nothing */
                     }
                 }
@@ -453,14 +444,11 @@ impl<'a, 'b: 'a> FunctionBuilder<'a, 'b> {
                 let end_lbl = self.new_empty_label();
                 let viter = self.new_varid();
 
-                let id = if !self.locals.contains_key(var)
-                {
+                let id = if !self.locals.contains_key(var) {
                     let id = self.new_varid();
                     self.locals.insert(var.to_owned(), id);
                     id
-                }
-                else
-                {
+                } else {
                     *self.locals.get(var).unwrap()
                 };
                 let vid = self.new_varid();

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,25 +1,25 @@
-use crate::msg::{Msg, MsgWithPos};
-use crate::reader::Reader;
-use crate::token::*;
-
 use std::collections::HashMap;
-pub struct Lexer
-{
+
+use hmap::hmap;
+
+use crate::{
+    msg::{Msg, MsgWithPos},
+    reader::Reader,
+    token::*,
+};
+
+pub struct Lexer {
     reader: Reader,
     keywords: HashMap<&'static str, TokenKind>,
 }
-use hmap::hmap;
 
-impl Lexer
-{
-    pub fn from_str(code: &str) -> Lexer
-    {
+impl Lexer {
+    pub fn from_str(code: &str) -> Lexer {
         let reader = Reader::from_string(code);
         Lexer::new(reader)
     }
 
-    pub fn new(reader: Reader) -> Lexer
-    {
+    pub fn new(reader: Reader) -> Lexer {
         let keywords = hmap!(
             "this" => TokenKind::This,
             "function" => TokenKind::Fun,
@@ -50,29 +50,27 @@ impl Lexer
             "include" => TokenKind::Include
         );
 
-        Lexer { reader: reader,
-                keywords: keywords }
+        Lexer {
+            reader: reader,
+            keywords: keywords,
+        }
     }
 
-    pub fn filename(&self) -> &str
-    {
+    pub fn filename(&self) -> &str {
         self.reader.filename()
     }
 
-    fn read_multi_comment(&mut self) -> Result<(), MsgWithPos>
-    {
+    fn read_multi_comment(&mut self) -> Result<(), MsgWithPos> {
         let pos = self.reader.pos();
 
         self.read_char();
         self.read_char();
 
-        while !self.cur().is_none() && !self.is_multi_comment_end()
-        {
+        while !self.cur().is_none() && !self.is_multi_comment_end() {
             self.read_char();
         }
 
-        if self.cur().is_none()
-        {
+        if self.cur().is_none() {
             return Err(MsgWithPos::new(pos, Msg::UnclosedComment));
         }
 
@@ -82,50 +80,32 @@ impl Lexer
         Ok(())
     }
 
-    pub fn read_token(&mut self) -> Result<Token, MsgWithPos>
-    {
-        loop
-        {
+    pub fn read_token(&mut self) -> Result<Token, MsgWithPos> {
+        loop {
             self.skip_white();
 
             let pos = self.reader.pos();
             let ch = self.cur();
 
-            if let None = ch
-            {
+            if let None = ch {
                 return Ok(Token::new(TokenKind::End, pos));
             }
 
-            if is_digit(ch)
-            {
+            if is_digit(ch) {
                 return self.read_number();
-            }
-            else if self.is_comment_start()
-            {
+            } else if self.is_comment_start() {
                 self.read_comment()?;
-            }
-            else if self.is_multi_comment_start()
-            {
+            } else if self.is_multi_comment_start() {
                 self.read_multi_comment()?;
-            }
-            else if is_identifier_start(ch)
-            {
+            } else if is_identifier_start(ch) {
                 return self.read_identifier();
-            }
-            else if is_quote(ch)
-            {
+            } else if is_quote(ch) {
                 return self.read_string();
-            }
-            else if is_char_quote(ch)
-            {
+            } else if is_char_quote(ch) {
                 return self.read_char_literal();
-            }
-            else if is_operator(ch)
-            {
+            } else if is_operator(ch) {
                 return self.read_operator();
-            }
-            else
-            {
+            } else {
                 let ch = ch.unwrap();
 
                 return Err(MsgWithPos::new(pos, Msg::UnknownChar(ch)));
@@ -133,21 +113,17 @@ impl Lexer
         }
     }
 
-    fn skip_white(&mut self)
-    {
-        while is_whitespace(self.cur())
-        {
+    fn skip_white(&mut self) {
+        while is_whitespace(self.cur()) {
             self.read_char();
         }
     }
 
-    fn read_identifier(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn read_identifier(&mut self) -> Result<Token, MsgWithPos> {
         let pos = self.reader.pos();
         let mut value = String::new();
 
-        while is_identifier(self.cur())
-        {
+        while is_identifier(self.cur()) {
             let ch = self.cur().unwrap();
             self.read_char();
             value.push(ch);
@@ -156,63 +132,47 @@ impl Lexer
         let lookup = self.keywords.get(&value[..]).cloned();
         let mut ttype;
 
-        if let Some(tok_type) = lookup
-        {
+        if let Some(tok_type) = lookup {
             ttype = tok_type;
-        }
-        else if value == "_"
-        {
+        } else if value == "_" {
             ttype = TokenKind::Underscore;
-        }
-        else
-        {
+        } else {
             ttype = TokenKind::Identifier(value);
         }
 
         Ok(Token::new(ttype, pos))
     }
 
-    fn read_char_literal(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn read_char_literal(&mut self) -> Result<Token, MsgWithPos> {
         let pos = self.reader.pos();
 
         self.read_char();
         let ch = self.read_escaped_char(pos, Msg::UnclosedChar)?;
 
-        if is_char_quote(self.cur())
-        {
+        if is_char_quote(self.cur()) {
             self.read_char();
 
             let ttype = TokenKind::LitChar(ch);
             Ok(Token::new(ttype, pos))
-        }
-        else
-        {
+        } else {
             Err(MsgWithPos::new(pos, Msg::UnclosedChar))
         }
     }
 
-    fn read_escaped_char(&mut self, pos: Position, unclosed: Msg) -> Result<char, MsgWithPos>
-    {
-        if let Some(ch) = self.cur()
-        {
+    fn read_escaped_char(&mut self, pos: Position, unclosed: Msg) -> Result<char, MsgWithPos> {
+        if let Some(ch) = self.cur() {
             self.read_char();
 
-            if ch == '\\'
-            {
-                let ch = if let Some(ch) = self.cur()
-                {
+            if ch == '\\' {
+                let ch = if let Some(ch) = self.cur() {
                     ch
-                }
-                else
-                {
+                } else {
                     return Err(MsgWithPos::new(pos, unclosed));
                 };
 
                 self.read_char();
 
-                match ch
-                {
+                match ch {
                     '\\' => Ok('\\'),
                     'n' => Ok('\n'),
                     't' => Ok('\t'),
@@ -220,70 +180,54 @@ impl Lexer
                     '\"' => Ok('\"'),
                     '\'' => Ok('\''),
                     '0' => Ok('\0'),
-                    _ =>
-                    {
+                    _ => {
                         let msg = Msg::InvalidEscapeSequence(ch);
                         Err(MsgWithPos::new(pos, msg))
                     }
                 }
-            }
-            else
-            {
+            } else {
                 Ok(ch)
             }
-        }
-        else
-        {
+        } else {
             Err(MsgWithPos::new(pos, unclosed))
         }
     }
 
-    fn read_string(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn read_string(&mut self) -> Result<Token, MsgWithPos> {
         let pos = self.reader.pos();
         let mut value = String::new();
 
         self.read_char();
 
-        while !self.cur().is_none() && !is_quote(self.cur())
-        {
+        while !self.cur().is_none() && !is_quote(self.cur()) {
             let ch = self.read_escaped_char(pos, Msg::UnclosedString)?;
             value.push(ch);
         }
 
-        if is_quote(self.cur())
-        {
+        if is_quote(self.cur()) {
             self.read_char();
 
             let ttype = TokenKind::String(value);
             Ok(Token::new(ttype, pos))
-        }
-        else
-        {
+        } else {
             Err(MsgWithPos::new(pos, Msg::UnclosedString))
         }
     }
 
-    fn read_operator(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn read_operator(&mut self) -> Result<Token, MsgWithPos> {
         let mut tok = self.build_token(TokenKind::End);
         let ch = self.cur().unwrap();
         self.read_char();
 
         let nch = self.cur().unwrap_or('x');
 
-        tok.kind = match ch
-        {
+        tok.kind = match ch {
             '+' => TokenKind::Add,
-            '-' =>
-            {
-                if nch == '>'
-                {
+            '-' => {
+                if nch == '>' {
                     self.read_char();
                     TokenKind::Arrow
-                }
-                else
-                {
+                } else {
                     TokenKind::Sub
                 }
             }
@@ -299,28 +243,20 @@ impl Lexer
             '{' => TokenKind::LBrace,
             '}' => TokenKind::RBrace,
 
-            '|' =>
-            {
-                if nch == '|'
-                {
+            '|' => {
+                if nch == '|' {
                     self.read_char();
                     TokenKind::Or
-                }
-                else
-                {
+                } else {
                     TokenKind::BitOr
                 }
             }
 
-            '&' =>
-            {
-                if nch == '&'
-                {
+            '&' => {
+                if nch == '&' {
                     self.read_char();
                     TokenKind::And
-                }
-                else
-                {
+                } else {
                     TokenKind::BitAnd
                 }
             }
@@ -329,42 +265,31 @@ impl Lexer
             '~' => TokenKind::Tilde,
             ',' => TokenKind::Comma,
             ';' => TokenKind::Semicolon,
-            ':' =>
-            {
-                if nch == ':'
-                {
+            ':' => {
+                if nch == ':' {
                     self.read_char();
                     TokenKind::Sep
-                }
-                else
-                {
+                } else {
                     TokenKind::Colon
                 }
             }
             '.' => TokenKind::Dot,
-            '=' =>
-            {
-                if nch == '='
-                {
+            '=' => {
+                if nch == '=' {
                     self.read_char();
                     TokenKind::EqEq
-                }
-                else
-                {
+                } else {
                     TokenKind::Eq
                 }
             }
 
-            '<' => match nch
-            {
-                '=' =>
-                {
+            '<' => match nch {
+                '=' => {
                     self.read_char();
                     TokenKind::Le
                 }
 
-                '<' =>
-                {
+                '<' => {
                     self.read_char();
                     TokenKind::LtLt
                 }
@@ -372,16 +297,13 @@ impl Lexer
                 _ => TokenKind::Lt,
             },
 
-            '>' => match nch
-            {
-                '=' =>
-                {
+            '>' => match nch {
+                '=' => {
                     self.read_char();
                     TokenKind::Ge
                 }
 
-                '>' =>
-                {
+                '>' => {
                     self.read_char();
 
                     TokenKind::GtGt
@@ -390,21 +312,16 @@ impl Lexer
                 _ => TokenKind::Gt,
             },
 
-            '!' =>
-            {
-                if nch == '='
-                {
+            '!' => {
+                if nch == '=' {
                     self.read_char();
                     TokenKind::Ne
-                }
-                else
-                {
+                } else {
                     TokenKind::Not
                 }
             }
 
-            _ =>
-            {
+            _ => {
                 return Err(MsgWithPos::new(tok.position, Msg::UnknownChar(ch)));
             }
         };
@@ -412,82 +329,66 @@ impl Lexer
         Ok(tok)
     }
 
-    fn read_comment(&mut self) -> Result<(), MsgWithPos>
-    {
-        while !self.cur().is_none() && !is_newline(self.cur())
-        {
+    fn read_comment(&mut self) -> Result<(), MsgWithPos> {
+        while !self.cur().is_none() && !is_newline(self.cur()) {
             self.read_char();
         }
 
         Ok(())
     }
 
-    fn read_digits(&mut self, buffer: &mut String, base: IntBase)
-    {
-        while is_digit_or_underscore(self.cur(), base)
-        {
+    fn read_digits(&mut self, buffer: &mut String, base: IntBase) {
+        while is_digit_or_underscore(self.cur(), base) {
             let ch = self.cur().unwrap();
             self.read_char();
             buffer.push(ch);
         }
     }
 
-    fn read_char(&mut self)
-    {
+    fn read_char(&mut self) {
         self.reader.advance();
     }
 
-    fn cur(&self) -> Option<char>
-    {
+    fn cur(&self) -> Option<char> {
         self.reader.cur()
     }
 
-    fn next(&self) -> Option<char>
-    {
+    fn next(&self) -> Option<char> {
         self.reader.next()
     }
 
-    fn build_token(&self, kind: TokenKind) -> Token
-    {
+    fn build_token(&self, kind: TokenKind) -> Token {
         Token::new(kind, self.reader.pos())
     }
 
-    fn is_comment_start(&self) -> bool
-    {
+    fn is_comment_start(&self) -> bool {
         self.cur() == Some('/') && self.next() == Some('/')
     }
 
-    fn is_multi_comment_start(&self) -> bool
-    {
+    fn is_multi_comment_start(&self) -> bool {
         self.cur() == Some('/') && self.next() == Some('*')
     }
 
-    fn is_multi_comment_end(&self) -> bool
-    {
+    fn is_multi_comment_end(&self) -> bool {
         self.cur() == Some('*') && self.next() == Some('/')
     }
 
-    fn read_number(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn read_number(&mut self) -> Result<Token, MsgWithPos> {
         let pos = self.reader.pos();
         let mut value = String::new();
 
-        let base = if self.cur() == Some('0')
-        {
+        let base = if self.cur() == Some('0') {
             let next = self.next();
 
-            match next
-            {
-                Some('x') =>
-                {
+            match next {
+                Some('x') => {
                     self.read_char();
                     self.read_char();
 
                     IntBase::Hex
                 }
 
-                Some('b') =>
-                {
+                Some('b') => {
                     self.read_char();
                     self.read_char();
 
@@ -496,28 +397,23 @@ impl Lexer
 
                 _ => IntBase::Dec,
             }
-        }
-        else
-        {
+        } else {
             IntBase::Dec
         };
 
         self.read_digits(&mut value, base);
 
-        if base == IntBase::Dec && self.cur() == Some('.') && is_digit(self.next())
-        {
+        if base == IntBase::Dec && self.cur() == Some('.') && is_digit(self.next()) {
             self.read_char();
             value.push('.');
 
             self.read_digits(&mut value, IntBase::Dec);
 
-            if self.cur() == Some('e') || self.cur() == Some('E')
-            {
+            if self.cur() == Some('e') || self.cur() == Some('E') {
                 value.push(self.cur().unwrap());
                 self.read_char();
 
-                if self.cur() == Some('+') || self.cur() == Some('-')
-                {
+                if self.cur() == Some('+') || self.cur() == Some('-') {
                     value.push(self.cur().unwrap());
                     self.read_char();
                 }
@@ -534,53 +430,43 @@ impl Lexer
     }
 }
 
-fn is_digit(ch: Option<char>) -> bool
-{
+fn is_digit(ch: Option<char>) -> bool {
     ch.map(|ch| ch.is_digit(10)).unwrap_or(false)
 }
 
-fn is_digit_or_underscore(ch: Option<char>, base: IntBase) -> bool
-{
+fn is_digit_or_underscore(ch: Option<char>, base: IntBase) -> bool {
     ch.map(|ch| ch.is_digit(base.num()) || ch == '_')
-      .unwrap_or(false)
+        .unwrap_or(false)
 }
 
-fn is_whitespace(ch: Option<char>) -> bool
-{
+fn is_whitespace(ch: Option<char>) -> bool {
     ch.map(|ch| ch.is_whitespace()).unwrap_or(false)
 }
 
-fn is_newline(ch: Option<char>) -> bool
-{
+fn is_newline(ch: Option<char>) -> bool {
     ch == Some('\n')
 }
 
-fn is_quote(ch: Option<char>) -> bool
-{
+fn is_quote(ch: Option<char>) -> bool {
     ch == Some('\"')
 }
 
-fn is_char_quote(ch: Option<char>) -> bool
-{
+fn is_char_quote(ch: Option<char>) -> bool {
     ch == Some('\'')
 }
 
-fn is_operator(ch: Option<char>) -> bool
-{
+fn is_operator(ch: Option<char>) -> bool {
     ch.map(|ch| "^+-*/%&|,=!~;:.()[]{}<>".contains(ch))
-      .unwrap_or(false)
+        .unwrap_or(false)
 }
 
-fn is_identifier_start(ch: Option<char>) -> bool
-{
-    match ch
-    {
+fn is_identifier_start(ch: Option<char>) -> bool {
+    match ch {
         Some(ch) => (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_',
         _ => false,
     }
 }
 
-fn is_identifier(ch: Option<char>) -> bool
-{
+fn is_identifier(ch: Option<char>) -> bool {
     is_identifier_start(ch) || is_digit(ch)
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,4 +55,3 @@ macro_rules! def {
         $compiler.vm.globals.insert(idx,gc!(waffle::value::Value::Object(idx)));
     };
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,10 @@ function sin(x) {
         let mut buff = String::new();
         use std::io::Read;
         let start = PreciseTime::now();
-        std::fs::File::open(path).unwrap()
-                                 .read_to_string(&mut buff)
-                                 .unwrap();
+        std::fs::File::open(path)
+            .unwrap()
+            .read_to_string(&mut buff)
+            .unwrap();
         string.push_str(&buff);
         let reader = Reader::from_string(&string);
 
@@ -61,8 +62,10 @@ function sin(x) {
         compiler.vm.run_function(*f);
         let end = PreciseTime::now();
 
-        println!("Compiling and execution time {} ms",
-                 start.to(end).num_milliseconds());
+        println!(
+            "Compiling and execution time {} ms",
+            start.to(end).num_milliseconds()
+        );
     } else {
         panic!("You should enter file path");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,24 @@
-extern crate jazz;
-extern crate structopt;
-
-use jazz::compiler::Compiler;
-use jazz::parser::Parser;
-use jazz::reader::Reader;
-
-use jazzvm::vm::VirtualMachine;
 use std::path::PathBuf;
+
 use structopt::StructOpt;
 use time::PreciseTime;
+
+use jazz::{compiler::Compiler, parser::Parser, reader::Reader};
+use jazzvm::vm::VirtualMachine;
+
 #[derive(StructOpt, Debug)]
-pub struct Options
-{
+pub struct Options {
     #[structopt(name = "FILE", parse(from_os_str))]
     file: Option<PathBuf>,
 }
 
-fn main()
-{
+fn main() {
     let ops = Options::from_args();
-    if let Some(path) = ops.file
-    {
+    if let Some(path) = ops.file {
         let path: PathBuf = path;
         let mut string = String::new();
         string.push_str(
-                        "
+            "
                     
                             function pow(x,y) {
     if y == 0 {
@@ -46,9 +40,10 @@ function sin(x) {
         );
         let mut buff = String::new();
         use std::io::Read;
-        std::fs::File::open(path).unwrap()
-                                 .read_to_string(&mut buff)
-                                 .unwrap();
+        std::fs::File::open(path)
+            .unwrap()
+            .read_to_string(&mut buff)
+            .unwrap();
         string.push_str(&buff);
         let reader = Reader::from_string(&string);
 
@@ -66,12 +61,12 @@ function sin(x) {
         let result = compiler.vm.run_function(*f);
         let end = PreciseTime::now();
 
-        println!("RESULT: {:?} in {} ms",
-                 result,
-                 start.to(end).num_milliseconds());
-    }
-    else
-    {
+        println!(
+            "RESULT: {:?} in {} ms",
+            result,
+            start.to(end).num_milliseconds()
+        );
+    } else {
         panic!("You should enter file path");
     }
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -4,8 +4,7 @@ use self::Msg::*;
 use crate::token::Position;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum Msg
-{
+pub enum Msg {
     Unimplemented,
     UnknownClass(String),
     UnknownType(String),
@@ -116,42 +115,36 @@ pub enum Msg
     StructFieldNotInitialized(String, String),
 }
 
-impl Msg
-{
-    pub fn message(&self) -> String
-    {
-        match *self
-        {
+impl Msg {
+    pub fn message(&self) -> String {
+        match *self {
             Unimplemented => format!("feature not implemented yet."),
             UnknownClass(ref name) => format!("class `{}` does not exist.", name),
             UnknownType(ref name) => format!("type `{}` does not exist.", name),
             UnknownIdentifier(ref name) => format!("unknown identifier `{}`.", name),
             UnknownStruct(ref name) => format!("unknown struct `{}`.", name),
             UnknownFunction(ref name) => format!("unknown function `{}`", name),
-            UnknownMethod(ref cls, ref name, ref args) =>
-            {
+            UnknownMethod(ref cls, ref name, ref args) => {
                 let args = args.join(", ");
-                format!("no method with definition `{}({})` in class `{}`.",
-                        name, args, cls)
+                format!(
+                    "no method with definition `{}({})` in class `{}`.",
+                    name, args, cls
+                )
             }
-            UnknownStaticMethod(ref cls, ref name, ref args) =>
-            {
+            UnknownStaticMethod(ref cls, ref name, ref args) => {
                 let args = args.join(", ");
                 format!("no static method `{}::{}({})`.", cls, name, args)
             }
-            UnknownCtor(ref name, ref args) =>
-            {
+            UnknownCtor(ref name, ref args) => {
                 let args = args.join(", ");
                 format!("no ctor with definition `{}({})`.", name, args)
             }
-            MethodExists(ref cls, ref name, pos) =>
-            {
-                format!("method with name `{}` already exists in class `{}` at line {}.",
-                        name, cls, pos)
-            }
+            MethodExists(ref cls, ref name, pos) => format!(
+                "method with name `{}` already exists in class `{}` at line {}.",
+                name, cls, pos
+            ),
             IncompatibleWithNil(ref ty) => format!("cannot assign `nil` to type `{}`.", ty),
-            UnknownField(ref field, ref ty) =>
-            {
+            UnknownField(ref field, ref ty) => {
                 format!("unknown field `{}` for type `{}`", field, ty)
             }
             IdentifierExists(ref name) => format!("can not redefine identifier `{}`.", name),
@@ -163,53 +156,46 @@ impl Msg
             ShadowField(ref name) => format!("field with name `{}` already exists.", name),
             ShadowGlobal(ref name) => format!("can not shadow global variable `{}`.", name),
             ShadowConst(ref name) => format!("can not shadow const `{}`", name),
-            VarNeedsTypeInfo(ref name) =>
-            {
-                format!("variable `{}` needs either type declaration or expression.",
-                        name)
-            }
-            ParamTypesIncompatible(ref name, ref def, ref expr) =>
-            {
+            VarNeedsTypeInfo(ref name) => format!(
+                "variable `{}` needs either type declaration or expression.",
+                name
+            ),
+            ParamTypesIncompatible(ref name, ref def, ref expr) => {
                 let def = def.join(", ");
                 let expr = expr.join(", ");
 
-                format!("function `{}({})` cannot be called as `{}({})`",
-                        name, def, name, expr)
+                format!(
+                    "function `{}({})` cannot be called as `{}({})`",
+                    name, def, name, expr
+                )
             }
-            WhileCondType(ref ty) =>
-            {
+            WhileCondType(ref ty) => {
                 format!("`while` expects condition of type `bool` but got `{}`.", ty)
             }
-            IfCondType(ref ty) =>
-            {
+            IfCondType(ref ty) => {
                 format!("`if` expects condition of type `bool` but got `{}`.", ty)
             }
-            ReturnType(ref def, ref expr) =>
-            {
-                format!("`return` expects value of type `{}` but got `{}`.",
-                        def, expr)
-            }
+            ReturnType(ref def, ref expr) => format!(
+                "`return` expects value of type `{}` but got `{}`.",
+                def, expr
+            ),
             LvalueExpected => format!("lvalue expected for assignment"),
-            AssignType(ref name, ref def, ref expr) =>
-            {
-                format!("cannot assign `{}` to variable `{}` of type `{}`.",
-                        expr, name, def)
-            }
-            AssignField(ref name, ref cls, ref def, ref expr) =>
-            {
-                format!("cannot assign `{}` to field `{}`.`{}` of type `{}`.",
-                        expr, cls, name, def)
-            }
-            UnOpType(ref op, ref expr) =>
-            {
-                format!("unary operator `{}` can not handle value of type `{} {}`.",
-                        op, op, expr)
-            }
-            BinOpType(ref op, ref lhs, ref rhs) =>
-            {
-                format!("binary operator `{}` can not handle expression of type `{} {} {}`",
-                        op, lhs, op, rhs)
-            }
+            AssignType(ref name, ref def, ref expr) => format!(
+                "cannot assign `{}` to variable `{}` of type `{}`.",
+                expr, name, def
+            ),
+            AssignField(ref name, ref cls, ref def, ref expr) => format!(
+                "cannot assign `{}` to field `{}`.`{}` of type `{}`.",
+                expr, cls, name, def
+            ),
+            UnOpType(ref op, ref expr) => format!(
+                "unary operator `{}` can not handle value of type `{} {}`.",
+                op, op, expr
+            ),
+            BinOpType(ref op, ref lhs, ref rhs) => format!(
+                "binary operator `{}` can not handle expression of type `{} {} {}`",
+                op, lhs, op, rhs
+            ),
             ConstValueExpected => "constant value expected".into(),
             OutsideLoop => "statement only allowed inside loops".into(),
             NoReturnValue => "function does not return a value in all code paths".into(),
@@ -217,8 +203,7 @@ impl Msg
             WrongMainDefinition => "`main` function has wrong definition".into(),
             ThisUnavailable => "`self` can only be used in methods not functions".into(),
             SelfTypeUnavailable => "`Self` can only be used in traits.".into(),
-            SuperUnavailable =>
-            {
+            SuperUnavailable => {
                 "`super` only available in methods of classes with parent class".into()
             }
             SuperNeedsMethodCall => "`super` only allowed in method calls".into(),
@@ -229,29 +214,23 @@ impl Msg
             LetReassigned => "`let` binding cannot be reassigned.".into(),
             UnderivableType(ref name) => format!("type `{}` cannot be used as super class.", name),
             CycleInHierarchy => "cycle in type hierarchy detected.".into(),
-            SuperfluousOverride(_) =>
-            {
+            SuperfluousOverride(_) => {
                 "method `{}` uses modifier `override` without overriding a function.".into()
             }
             MissingOverride(_) => "method `{}` is missing modifier `override`.".into(),
-            Superfluousimport(_) =>
-            {
+            Superfluousimport(_) => {
                 "method `{}` uses modifier `import` but class allows no subclasses.".into()
             }
-            ThrowsDifference(_) =>
-            {
+            ThrowsDifference(_) => {
                 "use of `throws` in method `{}`needs to match super class".into()
             }
-            MethodNotOverridable(ref name) =>
-            {
+            MethodNotOverridable(ref name) => {
                 format!("method `{}` in super class not overridable.", name)
             }
-            TypesIncompatible(ref na, ref nb) =>
-            {
+            TypesIncompatible(ref na, ref nb) => {
                 format!("types `{}` and `{}` incompatible.", na, nb)
             }
-            ReturnTypeMismatch(ref fct, ref sup) =>
-            {
+            ReturnTypeMismatch(ref fct, ref sup) => {
                 format!("return types `{}` and `{}` do not match.", fct, sup)
             }
             UnresolvedInternal => "unresolved internal.".into(),
@@ -264,12 +243,10 @@ impl Msg
             ExpectedType(ref got) => format!("type expected but got {}.", got),
             ExpectedIdentifier(ref tok) => format!("identifier expected but got {}.", tok),
             MisplacedModifier(ref modifier) => format!("misplaced modifier `{}`.", modifier),
-            ExpectedTopLevelElement(ref token) =>
-            {
+            ExpectedTopLevelElement(ref token) => {
                 format!("expected function or class but got {}.", token)
             }
-            ExpectedClassElement(ref token) =>
-            {
+            ExpectedClassElement(ref token) => {
                 format!("field or method expected but got {}.", token)
             }
             RedundantModifier(ref token) => format!("redundant modifier {}.", token),
@@ -282,53 +259,54 @@ impl Msg
             MissingFctBody => "missing function body.".into(),
             FctCallExpected => format!("function call expected"),
             ThisOrSuperExpected(ref val) => format!("`self` or `super` expected but got {}.", val),
-            NoSuperDelegationWithPrimaryCtor(ref name) =>
-            {
-                format!("no `super` delegation allowed for ctor in class {}, because class has \
-                         primary ctor.",
-                        name)
-            }
+            NoSuperDelegationWithPrimaryCtor(ref name) => format!(
+                "no `super` delegation allowed for ctor in class {}, because class has \
+                 primary ctor.",
+                name
+            ),
             NoSuperClass(ref name) => format!("class `{}` does not have super class.", name),
             RecursiveStructure => "recursive structure is not allowed.".into(),
             TraitMethodWithBody => "trait method is not allowed to have definition".into(),
             TryNeedsCall => "`try` expects function or method call.".into(),
             TryCallNonThrowing => "given function or method call for `try` does not throw.".into(),
-            ThrowingCallWithoutTry =>
-            {
+            ThrowingCallWithoutTry => {
                 "function or method call that is able to throw, needs `try`.".into()
             }
             TypeParamsExpected => "type params expected.".into(),
             TypeParamNameNotUnique(ref name) => format!("type param `{}` name already used.", name),
-            StaticMethodNotInTrait(ref trait_name, ref mtd_name, ref args) =>
-            {
+            StaticMethodNotInTrait(ref trait_name, ref mtd_name, ref args) => {
                 let args = args.join(", ");
 
-                format!("trait `{}` does not define static method `{}({})`.",
-                        trait_name, mtd_name, args)
+                format!(
+                    "trait `{}` does not define static method `{}({})`.",
+                    trait_name, mtd_name, args
+                )
             }
-            MethodNotInTrait(ref trait_name, ref mtd_name, ref args) =>
-            {
+            MethodNotInTrait(ref trait_name, ref mtd_name, ref args) => {
                 let args = args.join(", ");
 
-                format!("trait `{}` does not define method `{}({})`.",
-                        trait_name, mtd_name, args)
+                format!(
+                    "trait `{}` does not define method `{}({})`.",
+                    trait_name, mtd_name, args
+                )
             }
-            StaticMethodMissingFromTrait(ref trait_name, ref mtd_name, ref args) =>
-            {
+            StaticMethodMissingFromTrait(ref trait_name, ref mtd_name, ref args) => {
                 let args = args.join(", ");
 
-                format!("trait `{}` defines static method `{}({})` but is missing in `impl`.",
-                        trait_name, mtd_name, args)
+                format!(
+                    "trait `{}` defines static method `{}({})` but is missing in `impl`.",
+                    trait_name, mtd_name, args
+                )
             }
-            MethodMissingFromTrait(ref trait_name, ref mtd_name, ref args) =>
-            {
+            MethodMissingFromTrait(ref trait_name, ref mtd_name, ref args) => {
                 let args = args.join(", ");
 
-                format!("trait `{}` defines method `{}({})` but is missing in `impl`.",
-                        trait_name, mtd_name, args)
+                format!(
+                    "trait `{}` defines method `{}({})` but is missing in `impl`.",
+                    trait_name, mtd_name, args
+                )
             }
-            WrongNumberTypeParams(exp, actual) =>
-            {
+            WrongNumberTypeParams(exp, actual) => {
                 format!("expected {} type parameters but got {}.", exp, actual)
             }
             ClassExpected(ref name) => format!("`{}` is not a class.", name),
@@ -338,44 +316,35 @@ impl Msg
             NoTypeParamsExpected => "no type params allowed".into(),
             MultipleClassBounds => "multiple class bounds not allowed".into(),
             DuplicateTraitBound => "duplicate trait bound".into(),
-            ClassBoundNotSatisfied(ref name, ref xclass) =>
-            {
+            ClassBoundNotSatisfied(ref name, ref xclass) => {
                 format!("type `{}` not a subclass of `{}`.", name, xclass)
             }
-            TraitBoundNotSatisfied(ref name, ref xtrait) =>
-            {
+            TraitBoundNotSatisfied(ref name, ref xtrait) => {
                 format!("type `{}` does not implement trait `{}`.", name, xtrait)
             }
             AbstractMethodWithImplementation => "abstract methods cannot be implemented.".into(),
-            AbstractMethodNotInAbstractClass =>
-            {
+            AbstractMethodNotInAbstractClass => {
                 "abstract methods only allowed in abstract classes.".into()
             }
             NewAbstractClass => "cannot create object of abstract class.".into(),
-            MissingAbstractOverride(ref cls, ref name) =>
-            {
-                format!("missing override of abstract method `{}` in class `{}`.",
-                        cls, name)
-            }
-            ModifierNotAllowedForStaticMethod(ref modifier) =>
-            {
+            MissingAbstractOverride(ref cls, ref name) => format!(
+                "missing override of abstract method `{}` in class `{}`.",
+                cls, name
+            ),
+            ModifierNotAllowedForStaticMethod(ref modifier) => {
                 format!("modifier `{}` not allowed for static method.", modifier)
             }
-            GlobalInitializerNotSupported =>
-            {
+            GlobalInitializerNotSupported => {
                 "global variables do no support initial assignment for now.".into()
             }
-            MakeIteratorReturnType(ref ty) =>
-            {
-                format!("makeIterator() returns `{}` which does not implement Iterator.",
-                        ty)
-            }
-            UnknownStructField(ref struc, ref field) =>
-            {
+            MakeIteratorReturnType(ref ty) => format!(
+                "makeIterator() returns `{}` which does not implement Iterator.",
+                ty
+            ),
+            UnknownStructField(ref struc, ref field) => {
                 format!("struct `{}` does not have field named `{}`.", struc, field)
             }
-            StructFieldNotInitialized(ref struc, ref field) =>
-            {
+            StructFieldNotInitialized(ref struc, ref field) => {
                 format!("field `{}` in struct `{}` not initialized.", field, struc)
             }
         }
@@ -383,29 +352,23 @@ impl Msg
 }
 
 #[derive(Clone, Debug)]
-pub struct MsgWithPos
-{
+pub struct MsgWithPos {
     pub msg: Msg,
     pub pos: Position,
 }
 
-impl MsgWithPos
-{
-    pub fn new(pos: Position, msg: Msg) -> MsgWithPos
-    {
+impl MsgWithPos {
+    pub fn new(pos: Position, msg: Msg) -> MsgWithPos {
         MsgWithPos { pos: pos, msg: msg }
     }
 
-    pub fn message(&self) -> String
-    {
+    pub fn message(&self) -> String {
         format!("error at {}: {}", self.pos, self.msg.message())
     }
 }
 
-impl fmt::Display for MsgWithPos
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error>
-    {
+impl fmt::Display for MsgWithPos {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "error at {}: {}", self.pos, self.msg.message())
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,8 @@
-use crate::ast::*;
-use crate::lexer::*;
-use crate::msg::*;
-use crate::reader::Reader;
-use crate::token::*;
 use std::mem;
 
-pub struct Parser<'a>
-{
+use crate::{ast::*, lexer::*, msg::*, reader::Reader, token::*};
+
+pub struct Parser<'a> {
     lexer: Lexer,
     token: Token,
     ast: &'a mut Vec<Box<Expr>>,
@@ -14,59 +10,53 @@ pub struct Parser<'a>
 
 macro_rules! expr {
     ($e:expr,$pos:expr) => {
-        Box::new(Expr { pos: $pos,
-                        expr: $e })
+        Box::new(Expr {
+            pos: $pos,
+            expr: $e,
+        })
     };
 }
 
 type EResult = Result<Box<Expr>, MsgWithPos>;
 
-impl<'a> Parser<'a>
-{
-    pub fn new(reader: Reader, ast: &'a mut Vec<Box<Expr>>) -> Parser<'a>
-    {
-        Self { lexer: Lexer::new(reader),
-               token: Token::new(TokenKind::End, Position::new(1, 1)),
-               ast }
+impl<'a> Parser<'a> {
+    pub fn new(reader: Reader, ast: &'a mut Vec<Box<Expr>>) -> Parser<'a> {
+        Self {
+            lexer: Lexer::new(reader),
+            token: Token::new(TokenKind::End, Position::new(1, 1)),
+            ast,
+        }
     }
 
-    fn init(&mut self) -> Result<(), MsgWithPos>
-    {
+    fn init(&mut self) -> Result<(), MsgWithPos> {
         self.advance_token()?;
 
         Ok(())
     }
 
-    pub fn parse(&mut self) -> Result<(), MsgWithPos>
-    {
+    pub fn parse(&mut self) -> Result<(), MsgWithPos> {
         self.init()?;
-        while !self.token.is_eof()
-        {
+        while !self.token.is_eof() {
             self.parse_top_level()?;
         }
         Ok(())
     }
 
-    fn expect_token(&mut self, kind: TokenKind) -> Result<Token, MsgWithPos>
-    {
-        if self.token.kind == kind
-        {
+    fn expect_token(&mut self, kind: TokenKind) -> Result<Token, MsgWithPos> {
+        if self.token.kind == kind {
             let token = self.advance_token()?;
 
             Ok(token)
-        }
-        else
-        {
-            Err(MsgWithPos::new(self.token.position,
-                                Msg::ExpectedToken(kind.name().into(),
-                                                   self.token.name())))
+        } else {
+            Err(MsgWithPos::new(
+                self.token.position,
+                Msg::ExpectedToken(kind.name().into(), self.token.name()),
+            ))
         }
     }
 
-    fn parse_top_level(&mut self) -> Result<(), MsgWithPos>
-    {
-        let expr = match &self.token.kind
-        {
+    fn parse_top_level(&mut self) -> Result<(), MsgWithPos> {
+        let expr = match &self.token.kind {
             TokenKind::Fun => self.parse_function()?,
             TokenKind::Let | TokenKind::Var => self.parse_let()?,
             TokenKind::Class => self.parse_class()?,
@@ -79,50 +69,37 @@ impl<'a> Parser<'a>
         Ok(())
     }
 
-    fn parse_function_param(&mut self) -> Result<String, MsgWithPos>
-    {
+    fn parse_function_param(&mut self) -> Result<String, MsgWithPos> {
         let name = self.expect_identifier()?;
         Ok(name)
     }
 
-    fn parse_import(&mut self) -> EResult
-    {
+    fn parse_import(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Import)?.position;
-        if let ExprKind::ConstStr(s) = self.lit_str()?.expr
-        {
+        if let ExprKind::ConstStr(s) = self.lit_str()?.expr {
             return Ok(expr!(ExprKind::Import(s.clone()), pos));
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
 
-    fn parse_include(&mut self) -> EResult
-    {
+    fn parse_include(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Include)?.position;
-        if let ExprKind::ConstStr(s) = self.lit_str()?.expr
-        {
+        if let ExprKind::ConstStr(s) = self.lit_str()?.expr {
             return Ok(expr!(ExprKind::Include(s.clone()), pos));
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
 
-    fn parse_class(&mut self) -> EResult
-    {
+    fn parse_class(&mut self) -> EResult {
         let pos1 = self.expect_token(TokenKind::Class)?.position;
         let name = self.expect_identifier()?;
-        let impls = if self.token.is(TokenKind::Colon) || self.token.is(TokenKind::Implements)
-        {
+        let impls = if self.token.is(TokenKind::Colon) || self.token.is(TokenKind::Implements) {
             self.advance_token()?;
             let impls = self.parse_expression()?;
             Some(impls)
-        }
-        else
-        {
+        } else {
             None
         };
 
@@ -131,23 +108,17 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Class(name, block, impls), pos1))
     }
 
-    fn parse_function(&mut self) -> EResult
-    {
+    fn parse_function(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Fun)?.position;
         let name = self.expect_identifier()?;
         self.expect_token(TokenKind::LParen)?;
-        let params = if self.token.kind == TokenKind::RParen
-        {
+        let params = if self.token.kind == TokenKind::RParen {
             vec![]
-        }
-        else
-        {
+        } else {
             let mut tmp = vec![];
-            while !self.token.is(TokenKind::RParen)
-            {
+            while !self.token.is(TokenKind::RParen) {
                 tmp.push(self.expect_identifier()?);
-                if !self.token.is(TokenKind::RParen)
-                {
+                if !self.token.is(TokenKind::RParen) {
                     self.expect_token(TokenKind::Comma)?;
                 }
             }
@@ -158,38 +129,30 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Function(name, params, block), pos))
     }
 
-    fn parse_let(&mut self) -> EResult
-    {
+    fn parse_let(&mut self) -> EResult {
         let reassignable = self.token.is(TokenKind::Var);
 
         let pos = self.advance_token()?.position;
         let ident = self.expect_identifier()?;
-        let expr = if self.token.is(TokenKind::Eq)
-        {
+        let expr = if self.token.is(TokenKind::Eq) {
             self.expect_token(TokenKind::Eq)?;
             let expr = self.parse_expression()?;
             Some(expr)
-        }
-        else
-        {
+        } else {
             None
         };
         Ok(expr!(ExprKind::Var(reassignable, ident, expr), pos))
     }
 
-    fn parse_return(&mut self) -> EResult
-    {
+    fn parse_return(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Return)?.position;
         let expr = self.parse_expression()?;
         Ok(expr!(ExprKind::Return(Some(expr)), pos))
     }
 
-    fn parse_expression(&mut self) -> EResult
-    {
-        match self.token.kind
-        {
-            TokenKind::New =>
-            {
+    fn parse_expression(&mut self) -> EResult {
+        match self.token.kind {
+            TokenKind::New => {
                 let pos = self.advance_token()?.position;
                 let calling = self.parse_expression()?;
                 Ok(expr!(ExprKind::New(calling), pos))
@@ -210,56 +173,45 @@ impl<'a> Parser<'a>
         }
     }
 
-    fn parse_self(&mut self) -> EResult
-    {
+    fn parse_self(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::This)?.position;
         Ok(expr!(ExprKind::This, pos))
     }
 
-    fn parse_break(&mut self) -> EResult
-    {
+    fn parse_break(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Break)?.position;
         Ok(expr!(ExprKind::Break, pos))
     }
-    fn parse_continue(&mut self) -> EResult
-    {
+    fn parse_continue(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Continue)?.position;
         Ok(expr!(ExprKind::Continue, pos))
     }
 
-    fn parse_throw(&mut self) -> EResult
-    {
+    fn parse_throw(&mut self) -> EResult {
         let pos = self.token.position;
-        if let TokenKind::String(s) = self.token.clone().kind
-        {
+        if let TokenKind::String(s) = self.token.clone().kind {
             self.advance_token()?;
             return Ok(expr!(ExprKind::Throw(s.clone()), pos));
-        }
-        else
-        {
+        } else {
             panic!("String expected at {}", pos)
         }
     }
 
-    fn parse_while(&mut self) -> EResult
-    {
+    fn parse_while(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::While)?.position;
         let cond = self.parse_expression()?;
         let block = self.parse_block()?;
         Ok(expr!(ExprKind::While(cond, block), pos))
     }
 
-    fn parse_match(&mut self) -> EResult
-    {
+    fn parse_match(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Match)?.position;
         let value = self.parse_expression()?;
         self.expect_token(TokenKind::LBrace)?;
         let mut data = vec![];
         let mut or = None;
-        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof()
-        {
-            if self.token.is(TokenKind::Underscore)
-            {
+        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof() {
+            if self.token.is(TokenKind::Underscore) {
                 self.expect_token(TokenKind::Underscore)?;
                 self.expect_token(TokenKind::Arrow)?;
                 let expr = self.parse_expression()?;
@@ -277,46 +229,41 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Match(value, data, or), pos))
     }
 
-    fn parse_if(&mut self) -> EResult
-    {
+    fn parse_if(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::If)?.position;
         let cond = self.parse_expression()?;
         let then_block = self.parse_expression()?;
-        let else_block = if self.token.is(TokenKind::Else)
-        {
+        let else_block = if self.token.is(TokenKind::Else) {
             self.advance_token()?;
 
-            if self.token.is(TokenKind::If)
-            {
+            if self.token.is(TokenKind::If) {
                 let if_block = self.parse_if()?;
                 let block = expr!(ExprKind::Block(vec![if_block]), if_block.pos);
 
                 Some(block)
-            }
-            else
-            {
+            } else {
                 Some(self.parse_expression()?)
             }
-        }
-        else
-        {
+        } else {
             None
         };
 
         Ok(expr!(ExprKind::If(cond, then_block, else_block), pos))
     }
 
-    fn parse_class_block(&mut self) -> EResult
-    {
+    fn parse_class_block(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::LBrace)?.position;
         let mut exprs = vec![];
-        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof()
-        {
-            let expr = match self.token.kind
-            {
+        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof() {
+            let expr = match self.token.kind {
                 TokenKind::Fun => self.parse_function()?,
                 TokenKind::Let | TokenKind::Var => self.parse_let()?,
-                _ => return Err(MsgWithPos::new(pos, Msg::ExpectedClassElement("".to_owned()))),
+                _ => {
+                    return Err(MsgWithPos::new(
+                        pos,
+                        Msg::ExpectedClassElement("".to_owned()),
+                    ));
+                }
             };
             exprs.push(expr);
         }
@@ -324,12 +271,10 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Block(exprs), pos))
     }
 
-    fn parse_block(&mut self) -> EResult
-    {
+    fn parse_block(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::LBrace)?.position;
         let mut exprs = vec![];
-        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof()
-        {
+        while !self.token.is(TokenKind::RBrace) && !self.token.is_eof() {
             let expr = self.parse_expression()?;
             exprs.push(expr);
         }
@@ -337,10 +282,8 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Block(exprs), pos))
     }
 
-    fn create_binary(&mut self, tok: Token, left: Box<Expr>, right: Box<Expr>) -> Box<Expr>
-    {
-        let op = match tok.kind
-        {
+    fn create_binary(&mut self, tok: Token, left: Box<Expr>, right: Box<Expr>) -> Box<Expr> {
+        let op = match tok.kind {
             TokenKind::Eq => return expr!(ExprKind::Assign(left, right), tok.position),
             TokenKind::Or => "||",
             TokenKind::And => "&&",
@@ -366,13 +309,10 @@ impl<'a> Parser<'a>
         expr!(ExprKind::BinOp(left, op.to_owned(), right), tok.position)
     }
 
-    fn parse_binary(&mut self, precedence: u32) -> EResult
-    {
+    fn parse_binary(&mut self, precedence: u32) -> EResult {
         let mut left = self.parse_unary()?;
-        loop
-        {
-            let right_precedence = match self.token.kind
-            {
+        loop {
+            let right_precedence = match self.token.kind {
                 TokenKind::Or => 1,
                 TokenKind::And => 2,
                 TokenKind::Eq => 3,
@@ -385,13 +325,11 @@ impl<'a> Parser<'a>
                 TokenKind::BitOr | TokenKind::BitAnd | TokenKind::Caret => 6,
                 TokenKind::LtLt | TokenKind::GtGt | TokenKind::Add | TokenKind::Sub => 8,
                 TokenKind::Mul | TokenKind::Div | TokenKind::Mod => 9,
-                _ =>
-                {
+                _ => {
                     return Ok(left);
                 }
             };
-            if precedence >= right_precedence
-            {
+            if precedence >= right_precedence {
                 return Ok(left);
             }
 
@@ -403,15 +341,11 @@ impl<'a> Parser<'a>
         }
     }
 
-    pub fn parse_unary(&mut self) -> EResult
-    {
-        match self.token.kind
-        {
-            TokenKind::Add | TokenKind::Sub | TokenKind::Not =>
-            {
+    pub fn parse_unary(&mut self) -> EResult {
+        match self.token.kind {
+            TokenKind::Add | TokenKind::Sub | TokenKind::Not => {
                 let tok = self.advance_token()?;
-                let op = match tok.kind
-                {
+                let op = match tok.kind {
                     TokenKind::Add => String::from("+"),
                     TokenKind::Sub => String::from("-"),
                     TokenKind::Not => String::from("!"),
@@ -439,46 +373,35 @@ impl<'a> Parser<'a>
         Ok(expr!(ExprKind::Call(expr, args), expr.pos))
     }*/
 
-    pub fn parse_primary(&mut self) -> EResult
-    {
+    pub fn parse_primary(&mut self) -> EResult {
         let mut left = self.parse_factor()?;
-        loop
-        {
-            left = match self.token.kind
-            {
-                TokenKind::Dot =>
-                {
+        loop {
+            left = match self.token.kind {
+                TokenKind::Dot => {
                     let tok = self.advance_token()?;
                     let ident = self.expect_identifier()?;
                     expr!(ExprKind::Access(left, ident), tok.position)
                 }
 
-                TokenKind::LBracket =>
-                {
+                TokenKind::LBracket => {
                     let tok = self.advance_token()?;
                     let val_or_index = self.parse_expression()?;
-                    if self.token.is(TokenKind::Comma)
-                    {
+                    if self.token.is(TokenKind::Comma) {
                         self.advance_token()?;
                         let mut vals = vec![val_or_index];
 
-                        while !self.token.is(TokenKind::RBracket)
-                        {
+                        while !self.token.is(TokenKind::RBracket) {
                             vals.push(self.parse_expression()?);
                         }
                         self.expect_token(TokenKind::RBracket)?;
                         expr!(ExprKind::Array(vals), tok.position)
-                    }
-                    else
-                    {
+                    } else {
                         self.expect_token(TokenKind::RBracket)?;
                         expr!(ExprKind::ArrayIndex(left, val_or_index), tok.position)
                     }
                 }
-                _ =>
-                {
-                    if self.token.is(TokenKind::LParen)
-                    {
+                _ => {
+                    if self.token.is(TokenKind::LParen) {
                         let expr = left;
 
                         self.expect_token(TokenKind::LParen)?;
@@ -487,9 +410,7 @@ impl<'a> Parser<'a>
                             self.parse_comma_list(TokenKind::RParen, |p| p.parse_expression())?;
 
                         expr!(ExprKind::Call(expr, args), expr.pos)
-                    }
-                    else
-                    {
+                    } else {
                         return Ok(left);
                     }
                 }
@@ -497,45 +418,43 @@ impl<'a> Parser<'a>
         }
     }
 
-    fn expect_identifier(&mut self) -> Result<String, MsgWithPos>
-    {
+    fn expect_identifier(&mut self) -> Result<String, MsgWithPos> {
         let tok = self.advance_token()?;
 
-        if let TokenKind::Identifier(ref value) = tok.kind
-        {
+        if let TokenKind::Identifier(ref value) = tok.kind {
             Ok(value.to_owned())
-        }
-        else
-        {
-            Err(MsgWithPos::new(tok.position, Msg::ExpectedIdentifier(tok.name())))
+        } else {
+            Err(MsgWithPos::new(
+                tok.position,
+                Msg::ExpectedIdentifier(tok.name()),
+            ))
         }
     }
 
-    fn parse_comma_list<F, R>(&mut self,
-                              stop: TokenKind,
-                              mut parse: F)
-                              -> Result<Vec<R>, MsgWithPos>
-        where F: FnMut(&mut Parser) -> Result<R, MsgWithPos>
+    fn parse_comma_list<F, R>(
+        &mut self,
+        stop: TokenKind,
+        mut parse: F,
+    ) -> Result<Vec<R>, MsgWithPos>
+    where
+        F: FnMut(&mut Parser) -> Result<R, MsgWithPos>,
     {
         let mut data = vec![];
         let mut comma = true;
 
-        while !self.token.is(stop.clone()) && !self.token.is_eof()
-        {
-            if !comma
-            {
-                return Err(MsgWithPos::new(self.token.position,
-                                           Msg::ExpectedToken(TokenKind::Comma.name()
-                                                                              .into(),
-                                                              self.token.name())));
+        while !self.token.is(stop.clone()) && !self.token.is_eof() {
+            if !comma {
+                return Err(MsgWithPos::new(
+                    self.token.position,
+                    Msg::ExpectedToken(TokenKind::Comma.name().into(), self.token.name()),
+                ));
             }
 
             let entry = parse(self)?;
             data.push(entry);
 
             comma = self.token.is(TokenKind::Comma);
-            if comma
-            {
+            if comma {
                 self.advance_token()?;
             }
         }
@@ -545,56 +464,41 @@ impl<'a> Parser<'a>
         Ok(data)
     }
 
-    fn advance_token(&mut self) -> Result<Token, MsgWithPos>
-    {
+    fn advance_token(&mut self) -> Result<Token, MsgWithPos> {
         let tok = self.lexer.read_token()?;
 
         Ok(mem::replace(&mut self.token, tok))
     }
 
-    fn parse_lambda(&mut self) -> EResult
-    {
+    fn parse_lambda(&mut self) -> EResult {
         let tok = self.advance_token()?;
-        let params = if tok.kind == TokenKind::Or
-        {
+        let params = if tok.kind == TokenKind::Or {
             vec![]
-        }
-        else
-        {
+        } else {
             self.parse_comma_list(TokenKind::BitOr, |f| f.parse_function_param())?
         };
 
         let block = self.parse_expression()?;
         Ok(expr!(ExprKind::Lambda(params, block), tok.position))
     }
-    pub fn parse_factor(&mut self) -> EResult
-    {
-        let expr = match self.token.kind
-        {
+    pub fn parse_factor(&mut self) -> EResult {
+        let expr = match self.token.kind {
             TokenKind::Fun => self.parse_function(),
-            TokenKind::LBracket =>
-            {
+            TokenKind::LBracket => {
                 let skip_contents = self.advance_token()?;
-                let skip = if skip_contents.is(TokenKind::RBracket)
-                {
+                let skip = if skip_contents.is(TokenKind::RBracket) {
                     true
-                }
-                else
-                {
+                } else {
                     false
                 };
                 let mut vals = vec![];
-                if !skip
-                {
-                    loop
-                    {
+                if !skip {
+                    loop {
                         vals.push(self.parse_expression()?);
-                        if self.token.is(TokenKind::Comma)
-                        {
+                        if self.token.is(TokenKind::Comma) {
                             self.advance_token()?;
                         }
-                        if self.token.is(TokenKind::RBracket)
-                        {
+                        if self.token.is(TokenKind::RBracket) {
                             //self.advance_token()?;
                             break;
                         }
@@ -615,100 +519,77 @@ impl<'a> Parser<'a>
             TokenKind::False => self.parse_bool_literal(),
             TokenKind::Nil => self.parse_nil(),
 
-            _ => Err(MsgWithPos::new(self.token.position,
-                                     Msg::ExpectedFactor(self.token
-                                                             .name()
-                                                             .clone()))),
+            _ => Err(MsgWithPos::new(
+                self.token.position,
+                Msg::ExpectedFactor(self.token.name().clone()),
+            )),
         };
 
         expr
     }
 
-    fn parse_parentheses(&mut self) -> EResult
-    {
+    fn parse_parentheses(&mut self) -> EResult {
         self.advance_token()?;
         let expr = self.parse_expression();
         self.expect_token(TokenKind::RParen)?;
         expr
     }
 
-    fn parse_nil(&mut self) -> EResult
-    {
+    fn parse_nil(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
-        if let TokenKind::Nil = tok.kind
-        {
+        if let TokenKind::Nil = tok.kind {
             Ok(expr!(ExprKind::Nil, pos))
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
 
-    fn parse_bool_literal(&mut self) -> EResult
-    {
+    fn parse_bool_literal(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let value = tok.is(TokenKind::True);
         Ok(expr!(ExprKind::ConstBool(value), tok.position))
     }
 
-    fn lit_int(&mut self) -> EResult
-    {
+    fn lit_int(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
-        if let TokenKind::LitInt(i, _, _) = tok.kind
-        {
+        if let TokenKind::LitInt(i, _, _) = tok.kind {
             Ok(expr!(ExprKind::ConstInt(i.parse().unwrap()), pos))
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
 
-    fn lit_char(&mut self) -> EResult
-    {
+    fn lit_char(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
-        if let TokenKind::LitChar(c) = tok.kind
-        {
+        if let TokenKind::LitChar(c) = tok.kind {
             Ok(expr!(ExprKind::ConstChar(c), pos))
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
-    fn lit_float(&mut self) -> EResult
-    {
+    fn lit_float(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
-        if let TokenKind::LitFloat(c) = tok.kind
-        {
+        if let TokenKind::LitFloat(c) = tok.kind {
             Ok(expr!(ExprKind::ConstFloat(c.parse().unwrap()), pos))
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
-    fn lit_str(&mut self) -> EResult
-    {
+    fn lit_str(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
-        if let TokenKind::String(s) = tok.kind
-        {
+        if let TokenKind::String(s) = tok.kind {
             Ok(expr!(ExprKind::ConstStr(s), pos))
-        }
-        else
-        {
+        } else {
             unreachable!()
         }
     }
 
-    fn ident(&mut self) -> EResult
-    {
+    fn ident(&mut self) -> EResult {
         let pos = self.token.position;
         let ident = self.expect_identifier()?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -110,8 +110,7 @@ impl<'a> Parser<'a> {
 
     fn parse_function(&mut self) -> EResult {
         let pos = self.expect_token(TokenKind::Fun)?.position;
-        let name = match &self.token.kind
-        {
+        let name = match &self.token.kind {
             TokenKind::Identifier(ident) => ident.clone(),
             TokenKind::Add => "_add_".to_owned(),
             TokenKind::Sub => "_sub_".to_owned(),
@@ -216,23 +215,17 @@ impl<'a> Parser<'a> {
         let pos = self.expect_token(TokenKind::For)?.position;
 
         let decl = self.parse_expression()?;
-        if self.token.is(TokenKind::In)
-        {
+        if self.token.is(TokenKind::In) {
             self.advance_token()?;
             let in_ = self.parse_expression()?;
             let block = self.parse_expression()?;
-            let name = if let ExprKind::Ident(name) = decl.expr
-            {
+            let name = if let ExprKind::Ident(name) = decl.expr {
                 name.clone()
-            }
-            else
-            {
+            } else {
                 unimplemented!()
             };
             Ok(expr!(ExprKind::ForIn(name, in_, block), pos))
-        }
-        else
-        {
+        } else {
             self.expect_token(TokenKind::Semicolon)?;
 
             let cond = self.parse_expression()?;
@@ -528,7 +521,7 @@ impl<'a> Parser<'a> {
         let block = self.parse_expression()?;
         Ok(expr!(ExprKind::Lambda(params, block), tok.position))
     }
-    
+
     pub fn parse_factor(&mut self) -> EResult {
         let expr = match self.token.kind {
             TokenKind::Fun => self.parse_function(),
@@ -618,7 +611,7 @@ impl<'a> Parser<'a> {
             unreachable!()
         }
     }
-    
+
     fn lit_float(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;
@@ -628,7 +621,7 @@ impl<'a> Parser<'a> {
             unreachable!()
         }
     }
-    
+
     fn lit_str(&mut self) -> EResult {
         let tok = self.advance_token()?;
         let pos = tok.position;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,10 +1,11 @@
-use std::fs::File;
-use std::io::{self, Error, Read};
+use std::{
+    fs::File,
+    io::{self, Error, Read},
+};
 
 use crate::token::Position;
 
-pub struct Reader
-{
+pub struct Reader {
     filename: String,
     pub src: String,
 
@@ -17,18 +18,15 @@ pub struct Reader
     tabwidth: usize,
 }
 
-impl Reader
-{
-    pub fn from_input() -> Result<Reader, Error>
-    {
+impl Reader {
+    pub fn from_input() -> Result<Reader, Error> {
         let mut src = String::new();
         io::stdin().read_to_string(&mut src)?;
 
         Ok(common_init("<<stdin>>".into(), src))
     }
 
-    pub fn from_file(filename: &str) -> Result<Reader, Error>
-    {
+    pub fn from_file(filename: &str) -> Result<Reader, Error> {
         let mut src = String::new();
 
         let mut file = File::open(filename)?;
@@ -37,97 +35,83 @@ impl Reader
         Ok(common_init(filename.into(), src))
     }
 
-    pub fn from_string(src: &str) -> Reader
-    {
+    pub fn from_string(src: &str) -> Reader {
         common_init("<<code>>".into(), src.into())
     }
 
-    pub fn set_tabwidth(&mut self, width: usize)
-    {
+    pub fn set_tabwidth(&mut self, width: usize) {
         self.tabwidth = width;
     }
 
-    pub fn filename(&self) -> &str
-    {
+    pub fn filename(&self) -> &str {
         &self.filename
     }
 
-    pub fn advance(&mut self) -> Option<char>
-    {
-        match self.cur
-        {
-            Some('\n') =>
-            {
+    pub fn advance(&mut self) -> Option<char> {
+        match self.cur {
+            Some('\n') => {
                 self.line += 1;
                 self.col = 1;
             }
 
-            Some('\t') =>
-            {
+            Some('\t') => {
                 let tabdepth = (self.col - 1) / self.tabwidth;
                 self.col = 1 + self.tabwidth * (tabdepth + 1);
             }
 
-            Some(_) =>
-            {
+            Some(_) => {
                 self.col += 1;
             }
 
             None => panic!("advancing from eof"),
         }
 
-        self.cur = if self.next_pos < self.src.len()
-        {
+        self.cur = if self.next_pos < self.src.len() {
             let ch = self.src[self.next_pos..].chars().next().unwrap();
             self.pos = self.next_pos;
             self.next_pos += ch.len_utf8();
 
             Some(ch)
-        }
-        else
-        {
+        } else {
             None
         };
 
         self.cur
     }
 
-    pub fn cur(&self) -> Option<char>
-    {
+    pub fn cur(&self) -> Option<char> {
         self.cur
     }
 
-    pub fn pos(&self) -> Position
-    {
-        Position { line: self.line as u32,
-                   column: self.col as u32 }
+    pub fn pos(&self) -> Position {
+        Position {
+            line: self.line as u32,
+            column: self.col as u32,
+        }
     }
 
-    pub fn next(&self) -> Option<char>
-    {
-        if self.next_pos < self.src.len()
-        {
+    pub fn next(&self) -> Option<char> {
+        if self.next_pos < self.src.len() {
             let ch = self.src[self.next_pos..].chars().next().unwrap();
             Some(ch)
-        }
-        else
-        {
+        } else {
             None
         }
     }
 }
 
-fn common_init(name: String, src: String) -> Reader
-{
-    let mut reader = Reader { filename: name,
-                              src: src,
-                              pos: 0,
-                              next_pos: 0,
+fn common_init(name: String, src: String) -> Reader {
+    let mut reader = Reader {
+        filename: name,
+        src: src,
+        pos: 0,
+        next_pos: 0,
 
-                              cur: Some('\n'),
-                              line: 0,
-                              col: 0,
-                              tabwidth: 4 };
+        cur: Some('\n'),
+        line: 0,
+        col: 0,
+        tabwidth: 4,
+    };
 
     reader.advance();
 
@@ -135,13 +119,11 @@ fn common_init(name: String, src: String) -> Reader
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::*;
 
     #[test]
-    fn read_from_str()
-    {
+    fn read_from_str() {
         let mut reader = Reader::from_string("abc");
 
         assert_eq!(Some('a'), reader.cur());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,4 @@
-use jazzvm::{frame::Frame, value::*, api::*};
+use jazzvm::{api::*, frame::Frame, value::*};
 use sdl2_sys::*;
 
 use crate::compiler::Compiler;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -29,8 +29,6 @@ macro_rules! func {
 }
 
 fn val_as_cstr(val: &GcValue) -> *const i8 {
-    use std::ffi::CString;
-
     val.map(&mut |val| match val {
         Value::Str(s) => s.as_bytes().as_ptr() as *const i8,
         _ => panic!("String value expected"),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,6 @@
-use jazzvm::frame::Frame;
-use jazzvm::value::*;
+use jazzvm::{frame::Frame, value::*};
+
+use crate::compiler::Compiler;
 
 macro_rules! func {
     ($compiler: expr ; function $name : ident ($framename: ident;$($arg:ident),*) $b:block ) => {
@@ -26,39 +27,29 @@ macro_rules! func {
     };
 }
 
-use crate::compiler::Compiler;
-
-pub fn string(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn string(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let v_clon = args[0].clone();
     let val: &Value = &args[0].get();
-    let string: String = match val
-    {
+    let string: String = match val {
         Value::Str(s) => s.clone(),
         Value::Float(f) => f.to_string(),
         Value::Int(i) => i.to_string(),
         Value::Bool(b) => b.to_string(),
         Value::Null => "null".to_owned(),
-        Value::Array(values) =>
-        {
+        Value::Array(values) => {
             let mut buff = String::new();
             let mut i = 0;
             buff.push('[');
-            while i < values.len()
-            {
+            while i < values.len() {
                 let s = string(frame, vec![values[i].clone()]);
                 let s: &Value = &s.get();
-                let vstr = if let Value::Str(s) = s
-                {
+                let vstr = if let Value::Str(s) = s {
                     s.clone()
-                }
-                else
-                {
+                } else {
                     unreachable!()
                 };
                 buff.push_str(&vstr);
-                if i != values.len() - 1
-                {
+                if i != values.len() - 1 {
                     buff.push(',');
                 }
                 i += 1;
@@ -66,17 +57,13 @@ pub fn string(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
             buff.push(']');
             buff
         }
-        Value::Object(obj) =>
-        {
+        Value::Object(obj) => {
             let f = obj.find(&GcValue::new(Value::Str(format!("display"))));
             let result = frame.invoke(&f.clone(), v_clon, 0);
             let vref: &Value = &result.get();
-            let string = if let Value::Str(s) = vref
-            {
+            let string = if let Value::Str(s) = vref {
                 s.to_owned()
-            }
-            else
-            {
+            } else {
                 panic!("String expected")
             };
             string
@@ -86,154 +73,119 @@ pub fn string(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
     GcValue::new(Value::Str(string))
 }
 
-fn to_string(val: &GcValue) -> String
-{
+fn to_string(val: &GcValue) -> String {
     let val: &Value = &val.get();
-    if let Value::Str(s) = val
-    {
+    if let Value::Str(s) = val {
         return s.to_string();
-    }
-    else
-    {
+    } else {
         panic!("String value expected");
     }
 }
 
-pub fn println(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn println(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let s = string(frame, args);
     let s_ref: &Value = &s.get();
-    if let Value::Str(s) = s_ref
-    {
+    if let Value::Str(s) = s_ref {
         println!("{}", s);
-    }
-    else
-    {
+    } else {
         panic!("String expected");
     }
     GcValue::new(Value::Null)
 }
 
-pub fn apush(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn apush(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let vref = args[0].clone();
     let array: &mut Value = &mut vref.get_mut();
     let val = args[1].clone();
-    if let Value::Array(values) = array
-    {
+    if let Value::Array(values) = array {
         values.push(val);
     }
     GcValue::new(Value::Null)
 }
 
-pub fn apop(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn apop(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let array: &mut Value = &mut args.get(0).unwrap().get_mut();
-    if let Value::Array(values) = array
-    {
+    if let Value::Array(values) = array {
         return values.pop().unwrap_or(GcValue::new(Value::Null));
-    }
-    else
-    {
+    } else {
         panic!("Array expected; apop,found: {:?}", array);
     }
 }
 
-pub fn len(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn len(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let val: &Value = &args[0].get();
 
-    match val
-    {
+    match val {
         Value::Str(s) => GcValue::new(Value::Int(s.len() as i64)),
         Value::Array(arr) => GcValue::new(Value::Int(arr.len() as i64)),
         _ => GcValue::new(Value::Int(-1)),
     }
 }
-pub fn aget(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn aget(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let array: &Value = &args[0].get();
     let idx: &Value = &args[1].get();
-    let idx_usize = if let Value::Int(i) = idx
-    {
+    let idx_usize = if let Value::Int(i) = idx {
         *i as usize
-    }
-    else
-    {
+    } else {
         panic!("Integer expected")
     };
-    if let Value::Array(values) = array
-    {
+    if let Value::Array(values) = array {
         return values[idx_usize].clone();
-    }
-    else
-    {
+    } else {
         panic!("Array expected")
     }
 }
 
-pub fn aset(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn aset(_frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let vref = args[0].clone();
     let array: &mut Value = &mut vref.get_mut();
     let vref = args[1].clone();
     let idx: &Value = &vref.get();
     let val = args[2].clone();
-    let idx_usize = if let Value::Int(i) = idx
-    {
+    let idx_usize = if let Value::Int(i) = idx {
         *i as usize
-    }
-    else
-    {
+    } else {
         panic!("Integer expected")
     };
-    if let Value::Array(values) = array
-    {
+    if let Value::Array(values) = array {
         values[idx_usize] = val;
-    }
-    else
-    {
+    } else {
         panic!("Array expected");
     }
     GcValue::new(Value::Null)
 }
 
-pub fn strtrim(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn strtrim(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let s = to_string(&args[0]);
     GcValue::new(Value::Str(s.trim().to_owned()))
 }
 
-pub fn str2chars(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn str2chars(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let s = to_string(&args[0]);
     let mut buff = vec![];
-    for ch in s.chars()
-    {
+    for ch in s.chars() {
         buff.push(GcValue::new(Value::Str(format!("{}", ch))));
     }
 
     GcValue::new(Value::Array(buff))
 }
 
-pub fn open_file(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn open_file(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let s = to_string(&args[0]);
     let mut buff = String::new();
     use std::io::Read;
-    std::fs::File::open(&s).unwrap()
-                           .read_to_string(&mut buff)
-                           .unwrap();
+    std::fs::File::open(&s)
+        .unwrap()
+        .read_to_string(&mut buff)
+        .unwrap();
     return GcValue::new(Value::Str(buff));
 }
 
-pub fn builtin_sqrt(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn builtin_sqrt(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let val = &args[0];
     let val_ref: &Value = &val.get();
 
-    let val = match val_ref
-    {
+    let val = match val_ref {
         Value::Int(i) => Value::Float((*i as f64).sqrt()),
         Value::Float(f) => Value::Float(f.sqrt()),
         _ => unreachable!(),
@@ -241,33 +193,25 @@ pub fn builtin_sqrt(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
     GcValue::new(val)
 }
 
-pub fn builtin_sin(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-{
+pub fn builtin_sin(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
     let val = &args[0];
     let val_ref: &Value = &val.get();
-    let val = match val_ref
-    {
+    let val = match val_ref {
         Value::Float(f) => Value::Float(f.sin()),
         Value::Int(i) => Value::Float((*i as f64).sin()),
         _ => unreachable!(),
     };
     GcValue::new(val)
 }
-pub fn builtins(cmpl: &mut Compiler)
-{
-    fn concat(frame: &mut Frame, args: Vec<GcValue>) -> GcValue
-    {
+pub fn builtins(cmpl: &mut Compiler) {
+    fn concat(frame: &mut Frame, args: Vec<GcValue>) -> GcValue {
         let mut buff = String::new();
-        for arg in args.iter()
-        {
+        for arg in args.iter() {
             let s = string(frame, vec![arg.clone()]);
             let s: &Value = &s.get();
-            if let Value::Str(ref s) = s
-            {
+            if let Value::Str(ref s) = s {
                 buff.push_str(s);
-            }
-            else
-            {
+            } else {
                 panic!("String expected");
             }
         }
@@ -275,28 +219,36 @@ pub fn builtins(cmpl: &mut Compiler)
         return GcValue::new(Value::Str(buff));
     }
 
-    let f = Function { name: String::from("concat"),
-                       var: FuncVar::Native(concat as i64) };
+    let f = Function {
+        name: String::from("concat"),
+        var: FuncVar::Native(concat as i64),
+    };
     let val = GcValue::new(Value::Func(f));
     let idx = cmpl.vm.new_global(val);
     cmpl.globals.insert(String::from("concat"), idx);
 
-    let f = Function { name: String::from("string"),
-                       var: FuncVar::Native(string as i64) };
+    let f = Function {
+        name: String::from("string"),
+        var: FuncVar::Native(string as i64),
+    };
     let val = GcValue::new(Value::Func(f));
     let idx = cmpl.vm.new_global(val);
     cmpl.globals.insert(String::from("string"), idx);
 
-    let f = Function { name: String::from("println"),
-                       var: FuncVar::Native(println as i64) };
+    let f = Function {
+        name: String::from("println"),
+        var: FuncVar::Native(println as i64),
+    };
     let val = GcValue::new(Value::Func(f));
     let idx = cmpl.vm.new_global(val);
     cmpl.globals.insert(String::from("println"), idx);
 
     macro_rules! reg_fn {
         ($compiler: expr,$name: ident) => {
-            let f = Function { name: String::from(stringify!($name)),
-                               var: FuncVar::Native($name as i64) };
+            let f = Function {
+                name: String::from(stringify!($name)),
+                var: FuncVar::Native($name as i64),
+            };
             let val = GcValue::new(Value::Func(f));
             let cmpl: &mut Compiler = $compiler;
             let idx = cmpl.vm.new_global(val);

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,31 +1,25 @@
 use std::fmt;
-use std::result::Result;
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
-pub struct Position
-{
+pub struct Position {
     pub line: u32,
     pub column: u32,
 }
-impl Position
-{
-    pub fn new(x: u32, y: u32) -> Self
-    {
+
+impl Position {
+    pub fn new(x: u32, y: u32) -> Self {
         Self { line: x, column: y }
     }
 }
 
-impl fmt::Display for Position
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
-    {
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({}:{})", self.line, self.column)
     }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum TokenKind
-{
+pub enum TokenKind {
     String(String),
     LitChar(char),
     LitInt(String, IntBase, IntSuffix),
@@ -106,15 +100,11 @@ pub enum TokenKind
     LtLt,
 }
 
-impl TokenKind
-{
-    pub fn name(&self) -> &str
-    {
-        match *self
-        {
+impl TokenKind {
+    pub fn name(&self) -> &str {
+        match *self {
             TokenKind::String(_) => "string",
-            TokenKind::LitInt(_, _, suffix) => match suffix
-            {
+            TokenKind::LitInt(_, _, suffix) => match suffix {
                 IntSuffix::Byte => "byte number",
                 IntSuffix::Int => "int number",
                 IntSuffix::Long => "long number",
@@ -201,46 +191,38 @@ impl TokenKind
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum IntSuffix
-{
+pub enum IntSuffix {
     Int,
     Long,
     Byte,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Token
-{
+pub struct Token {
     pub kind: TokenKind,
     pub position: Position,
 }
 
-impl Token
-{
-    pub fn new(tok: TokenKind, pos: Position) -> Token
-    {
-        Token { kind: tok,
-                position: pos }
+impl Token {
+    pub fn new(tok: TokenKind, pos: Position) -> Token {
+        Token {
+            kind: tok,
+            position: pos,
+        }
     }
 
-    pub fn is_eof(&self) -> bool
-    {
+    pub fn is_eof(&self) -> bool {
         self.kind == TokenKind::End
     }
 
-    pub fn is(&self, kind: TokenKind) -> bool
-    {
+    pub fn is(&self, kind: TokenKind) -> bool {
         self.kind == kind
     }
 
-    pub fn name(&self) -> String
-    {
-        match self.kind
-        {
-            TokenKind::LitInt(ref val, _, suffix) =>
-            {
-                let suffix = match suffix
-                {
+    pub fn name(&self) -> String {
+        match self.kind {
+            TokenKind::LitInt(ref val, _, suffix) => {
+                let suffix = match suffix {
                     IntSuffix::Byte => "B",
                     IntSuffix::Int => "",
                     IntSuffix::Long => "L",
@@ -257,28 +239,22 @@ impl Token
     }
 }
 
-impl fmt::Display for Token
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error>
-    {
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}", self.name())
     }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum IntBase
-{
+pub enum IntBase {
     Bin,
     Dec,
     Hex,
 }
 
-impl IntBase
-{
-    pub fn num(self) -> u32
-    {
-        match self
-        {
+impl IntBase {
+    pub fn num(self) -> u32 {
+        match self {
             IntBase::Bin => 2,
             IntBase::Dec => 10,
             IntBase::Hex => 16,

--- a/src/token.rs
+++ b/src/token.rs
@@ -105,6 +105,8 @@ pub enum TokenKind {
 impl TokenKind {
     pub fn name(&self) -> &str {
         match *self {
+            TokenKind::IncludeUrl => "includeurl",
+            TokenKind::ForEach => "foreach",
             TokenKind::String(_) => "string",
             TokenKind::LitInt(_, _, suffix) => match suffix {
                 IntSuffix::Byte => "byte number",


### PR DESCRIPTION
I propose that we use the default `rustfmt` formatting to make working with the code easier for everybody.
We can also fix the linter errors and optimize the code later.